### PR TITLE
Web UI: correct makefile to include host page

### DIFF
--- a/striker-ui/Makefile.am
+++ b/striker-ui/Makefile.am
@@ -11,6 +11,7 @@ outpages		= \
 			anvil.html \
 			config.html \
 			file-manager.html \
+			host.html \
 			index.html \
 			init.html \
 			login.html \


### PR DESCRIPTION
A new page was added in #914, but wasn't included in the makefile. This patch will add the missing page.